### PR TITLE
don't rely on nim bug, fix typo

### DIFF
--- a/patty.nim
+++ b/patty.nim
@@ -26,14 +26,14 @@ proc getFields(n: NimNode, pub: bool): seq[tuple[name, ty: NimNode]] =
         fieldName = if pub: postfix(e[0], "*") else: e[0]
         fieldType = e[1]
       for name in identsWithoutTypeDec:
-        result.add((name: name, ty: fieldType))
+        result.add((name: name, ty: fieldType.copyNimTree))
       identsWithoutTypeDec = @[]
-      result.add((name: fieldName, ty: fieldType))
+      result.add((name: fieldName, ty: fieldType.copyNimTree))
     elif e.kind == nnkIdent:
       let name = if pub: postfix(e, "*") else: e
       identsWithoutTypeDec.add(name)
     else:
-      error("Invalid feild declaration:" & $(toStrLit(e)))
+      error("Invalid field declaration:" & $(toStrLit(e)))
   if identsWithoutTypeDec.len > 0:
     error("Invalid ADT case: " & $(toStrLit(n)) & n.treeRepr)
 

--- a/test.nim
+++ b/test.nim
@@ -340,6 +340,15 @@ suite "pattern matching":
 
    check(res == 1)
 
+ test "generic variant":
+   type AccProc[T] = proc(): T {.nimcall.}
+
+   variant Accept[T]:
+     NotAcc
+     Acc(fun: AccProc[T])
+
+   discard Acc[int](nil)
+
  test "matching inside generic context":
    variant Foo:
      mkA


### PR DESCRIPTION
Nim implicitly copies NimNodes resulting from an index expression upon storage in a record type. see https://github.com/nim-lang/Nim/issues/12457

When this bug is fixed the added test fails with `cannot instantiate: 'T'`